### PR TITLE
Output ints instead of chars for numbers in array sizes

### DIFF
--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/NewExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/NewExprent.java
@@ -362,7 +362,13 @@ public class NewExprent extends Exprent {
           for (int i = 0; i < newType.arrayDim; i++) {
             buf.append("[");
             if (i < lstDims.size()) {
-              buf.append(lstDims.get(i).toJava(indent, tracer));
+              Exprent dim = lstDims.get(i);
+
+              if (dim.type == Exprent.EXPRENT_CONST) {
+                ((ConstExprent) dim).setConstType(VarType.VARTYPE_INT);
+              }
+
+              buf.append(dim.toJava(indent, tracer));
             }
             buf.append("]");
           }


### PR DESCRIPTION
Makes the chinese characters in e.g.

![](https://i.imgur.com/WoK5rbN.png)

into integers.